### PR TITLE
Update Invoke-LenovoInventory.ps1

### DIFF
--- a/Lenovo Inventory/Invoke-LenovoInventory.ps1
+++ b/Lenovo Inventory/Invoke-LenovoInventory.ps1
@@ -121,20 +121,7 @@ else {
     else {
 
         # Format warranty date for Azure Monitor Workbook
-        $s_Array = $Warranty.EndDate.Split("/")
-        if ($s_Array[0].Length -eq 1) { $s_Array[0] = "0" + $s_Array[0] }
-        if ($s_Array[1].Length -eq 1) { $s_Array[1] = "0" + $s_Array[1] }
-        $s_Array[2] = $s_Array[2].Substring(0, 4)
-        $Warranty = "{0}-{1}-{2}" -f $s_Array[2], $s_Array[0], $s_Array[1]
-        
-        if ($Warranty[0] -eq "-")
-            {
-               $Warranty = $Warranty.Substring(1,10)
-               $year = $Warranty.Substring(6)
-               $Month = $Warranty.Substring(3,2)
-               $Day = $Warranty.Substring(0,2)
-               $Warranty = "$($year)-$($Month)-$($Day)"
-            }
+        $Warranty = Get-Date -Date $Warranty.EndDate -UFormat "%Y-%m-%d"
     
         $Properties = foreach ($Update in $LenovoUpdates) {
             [PSCustomObject]@{

--- a/Lenovo Inventory/Invoke-LenovoInventory.ps1
+++ b/Lenovo Inventory/Invoke-LenovoInventory.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Collect Lenovo specific data and upload to Log Analytics
 
@@ -106,8 +106,18 @@ else {
         Write-Output "Run Commercial Vantage and initiate a check for updates..."; Exit 0
     }
 
+	$Chassis = (Get-CimInstance -ClassName Win32_SystemEnclosure).ChassisTypes
+	$Device_Chassis = [string]$chassis
+	If($Chassis -eq 9 -or $Chassis -eq 10 -or $Chassis -eq 14 -or $Chassis -eq 8 -or $Chassis -eq 11 -or $Chassis -eq 12 -or $Chassis -eq 18 -or $Chassis -eq 21 -or $Chassis -eq 31 -or $Chassis -eq 32) 
+		{
+		$Chassis_Type = "Laptop"
+		}
+	else 
+		{
+		$Chassis_Type = "Desktop"
+		}
     $Battery = Get-CimInstance -Namespace root/Lenovo -ClassName Lenovo_Battery
-    if ($null -eq $Battery) {
+    if ($null -eq $Battery -and $chassis_type -eq "Laptop") {
         Write-Output "Lenovo Battery WMI class not present."
         Write-Output "Enable the policy to write battery info to WMI..."; Exit 0
     }
@@ -461,17 +471,6 @@ $Current_User_Profile = Get-ChildItem Registry::\HKEY_USERS | Where-Object { Tes
 $Username = $Current_User_Profile.split("\")[2]	
 
 $BIOS_Ver_Model = "$Get_Current_BIOS_Version ($Get_Current_Model_FamilyName)"
-
-$Chassis = (Get-CimInstance -ClassName Win32_SystemEnclosure).ChassisTypes
-$Device_Chassis = [string]$chassis
-If($Chassis -eq 9 -or $Chassis -eq 10 -or $Chassis -eq 14 -or $Chassis -eq 8 -or $Chassis -eq 11 -or $Chassis -eq 12 -or $Chassis -eq 18 -or $Chassis -eq 21 -or $Chassis -eq 31 -or $Chassis -eq 32) 
-	{
-		$Chassis_Type = "Laptop"
-	}
-else 
-	{
-		$Chassis_Type = "Desktop"
-	}
 
 $BIOSConfiguration = (Get-WmiObject -Class Lenovo_BiosSetting -Namespace root\wmi).CurrentSetting
 


### PR DESCRIPTION
Warranty End Date was wrongly formatted for me.
Value in WMI is : "EndDate          : 2023-06-15 00:00:00"
Value reported to Log Analytics : "6-15-3--20"

Replaced the formatting commands with Get-Date and confirmed the script now returns the desired Warranty End Date value of 2023-06-15 in my case.