### PR TITLE
Secure Boot scripts v3.1: buffered logging, early compliance exit, task polling

### DIFF
--- a/Remediation/Secure Boot/Detect-SecureBootCertificateUpdate.ps1
+++ b/Remediation/Secure Boot/Detect-SecureBootCertificateUpdate.ps1
@@ -52,12 +52,16 @@
     Uses a 45-day fallback threshold and a custom registry path for the opt-in timestamp.
 
 .NOTES
-    Version:        3.0
+    Version:        3.1
     Author:         Mattias Melkersen
     Creation Date:  2026-01-15
     
     CHANGELOG
     ---------------
+    2026-04-05 - v3.1 - Buffered logging: accumulate entries in List[string], flush to disk once per run (MM)
+                        Added Flush-Log function; Write-Log no longer calls Add-Content on every line
+                        Moved Stage 5 compliance check before expensive diagnostic data collection
+                        Compliant devices now exit immediately without querying TPM/BitLocker/WU/reboot
     2026-03-27 - v3.0 - Added configurable fallback timer with FallbackDays and TimestampRegPath parameters (MM)
                         Detection output now includes fallback countdown for non-compliant Stages 2-4
                         Added Get-FallbackStatus helper function to read ManagedOptInDate timestamp
@@ -90,6 +94,7 @@ param(
 [string]$LogFile = "$env:ProgramData\Microsoft\IntuneManagementExtension\Logs\SecureBootCertificateUpdate.log"
 [string]$ScriptName = "DETECT"
 [int]$MaxLogSizeMB = 4
+$script:LogBuffer = [System.Collections.Generic.List[string]]::new()
 
 function Write-Log {
     param(
@@ -99,40 +104,31 @@ function Write-Log {
         [ValidateSet("INFO", "WARNING", "ERROR", "SUCCESS")]
         [string]$Level = "INFO"
     )
-    
     $TimeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $LogEntry = "$TimeStamp [$ScriptName] [$Level] $Message"
-    
+    $script:LogBuffer.Add("$TimeStamp [$ScriptName] [$Level] $Message")
+}
+
+function Flush-Log {
+    if ($script:LogBuffer.Count -eq 0) { return }
     try {
-        # Ensure log directory exists
         $LogDir = Split-Path -Path $LogFile -Parent
         if (-not (Test-Path $LogDir)) {
             New-Item -Path $LogDir -ItemType Directory -Force | Out-Null
         }
-        
-        # Check log file size and rotate if necessary
         if (Test-Path $LogFile) {
             $LogFileSizeMB = (Get-Item $LogFile).Length / 1MB
             if ($LogFileSizeMB -ge $MaxLogSizeMB) {
-                # Rotate log: rename current to .old
                 $BackupLog = "$LogFile.old"
-                
-                # Delete old backup if it exists (keep only N-1)
                 if (Test-Path $BackupLog) {
                     Remove-Item -Path $BackupLog -Force -ErrorAction SilentlyContinue
                 }
-                
-                # Rename current log to backup
                 Rename-Item -Path $LogFile -NewName $BackupLog -Force -ErrorAction SilentlyContinue
-                
-                # Create new log file with rotation notice
-                $RotationMsg = "$TimeStamp [SYSTEM] [INFO] Log rotated - Previous log archived to: $BackupLog"
-                Add-Content -Path $LogFile -Value $RotationMsg -ErrorAction SilentlyContinue
+                $TimeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+                $script:LogBuffer.Insert(0, "$TimeStamp [SYSTEM] [INFO] Log rotated - Previous log archived to: $BackupLog")
             }
         }
-        
-        # Write to log file
-        Add-Content -Path $LogFile -Value $LogEntry -ErrorAction SilentlyContinue
+        Add-Content -Path $LogFile -Value $script:LogBuffer.ToArray() -ErrorAction SilentlyContinue
+        $script:LogBuffer.Clear()
     }
     catch {
         # Silently fail if logging doesn't work - don't break script execution
@@ -274,6 +270,7 @@ try {
         Write-Host "SECURE_BOOT_DISABLED | Action: Enable Secure Boot in BIOS/UEFI"
         Write-Log -Message "Detection Result: NON-COMPLIANT - Stage 0 (exit 1)" -Level "WARNING"
         Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
+        Flush-Log
         exit 1
     }
     Write-Log -Message "Secure Boot is ENABLED" -Level "SUCCESS"
@@ -301,6 +298,7 @@ try {
         Write-Host "OPTIN_NOT_SET | Action: Remediation will configure registry"
         Write-Log -Message "Detection Result: NON-COMPLIANT - Stage 1 (exit 1)" -Level "WARNING"
         Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
+        Flush-Log
         exit 1
     }
     Write-Log -Message "MicrosoftUpdateManagedOptIn is SET to 0x$($optInValue.ToString('X')) ($optInValue)" -Level "SUCCESS"
@@ -334,6 +332,34 @@ try {
     }
     else {
         Write-Log -Message "WindowsUEFICA2023Capable: Key not present (normal before Windows Update processes)" -Level "INFO"
+    }
+    
+    # Build detail string for output (lightweight - no diagnostics needed)
+    $detailParts = @("OptIn:0x$($optInValue.ToString('X'))")
+    if ($null -ne $availableUpdates) {
+        $updateStatus = Get-AvailableUpdatesStatus -Value $availableUpdates
+        # Only include Updates detail if cert is not yet in DB (avoids confusion at Stage 4/5)
+        if ($null -eq $ca2023Capable -or $ca2023Capable -lt 1) {
+            $detailParts += "Updates:$updateStatus"
+        }
+    }
+    if ($null -ne $ca2023Capable) {
+        $ca2023Status = Get-WindowsUEFICA2023Status -Value $ca2023Capable
+        $detailParts += "CA2023:$ca2023Status"
+    }
+    $details = $detailParts -join " | "
+    
+    # -- Stage 5: COMPLIANT - Booting from 2023 cert chain --
+    # Check early to skip expensive diagnostic collection on compliant devices
+    if ($ca2023Capable -eq 2) {
+        Write-Log -Message "--- Stage 5: COMPLIANT ---" -Level "SUCCESS"
+        Write-Log -Message "  Device is booting from the 2023-signed boot manager" -Level "SUCCESS"
+        Write-Log -Message "  The Secure Boot certificate transition is complete for this device" -Level "SUCCESS"
+        Write-Host "COMPLIANT | $details"
+        Write-Log -Message "Detection Result: COMPLIANT - Stage 5 (exit 0)" -Level "SUCCESS"
+        Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
+        Flush-Log
+        exit 0
     }
     
     # Check device attributes
@@ -498,32 +524,6 @@ try {
     Write-Log -Message "--- End Registry Dump ---" -Level "INFO"
     Write-Log -Message "---------- END DIAGNOSTIC DATA ----------" -Level "INFO"
     
-    # Build detail string for output
-    $detailParts = @("OptIn:0x$($optInValue.ToString('X'))")
-    if ($null -ne $availableUpdates) {
-        $updateStatus = Get-AvailableUpdatesStatus -Value $availableUpdates
-        # Only include Updates detail if cert is not yet in DB (avoids confusion at Stage 4/5)
-        if ($null -eq $ca2023Capable -or $ca2023Capable -lt 1) {
-            $detailParts += "Updates:$updateStatus"
-        }
-    }
-    if ($null -ne $ca2023Capable) {
-        $ca2023Status = Get-WindowsUEFICA2023Status -Value $ca2023Capable
-        $detailParts += "CA2023:$ca2023Status"
-    }
-    $details = $detailParts -join " | "
-    
-    # -- Stage 5: COMPLIANT - Booting from 2023 cert chain --
-    if ($ca2023Capable -eq 2) {
-        Write-Log -Message "--- Stage 5: COMPLIANT ---" -Level "SUCCESS"
-        Write-Log -Message "  Device is booting from the 2023-signed boot manager" -Level "SUCCESS"
-        Write-Log -Message "  The Secure Boot certificate transition is complete for this device" -Level "SUCCESS"
-        Write-Host "COMPLIANT | $details"
-        Write-Log -Message "Detection Result: COMPLIANT - Stage 5 (exit 0)" -Level "SUCCESS"
-        Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
-        exit 0
-    }
-    
     # -- Stages 2-4: Configured but not yet fully transitioned (all exit 1) --
     # The remediation script will see OptIn is already set and may trigger direct fallback.
     # Add fallback timer info to detail string for non-compliant stages
@@ -560,6 +560,7 @@ try {
         Write-Host "CONFIGURED_CA2023_IN_DB | $details | Action: Reboot to complete transition"
         Write-Log -Message "Detection Result: NON-COMPLIANT - Stage 4 (exit 1)" -Level "WARNING"
         Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
+        Flush-Log
         exit 1
     }
     
@@ -584,6 +585,7 @@ try {
         Write-Host "CONFIGURED_UPDATE_IN_PROGRESS | $details | Action: Waiting for Windows Update"
         Write-Log -Message "Detection Result: NON-COMPLIANT - Stage 3 (exit 1)" -Level "WARNING"
         Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
+        Flush-Log
         exit 1
     }
     
@@ -615,6 +617,7 @@ try {
     Write-Host "CONFIGURED_AWAITING_UPDATE | $details | Action: Waiting for Windows Update scan"
     Write-Log -Message "Detection Result: NON-COMPLIANT - Stage 2 (exit 1)" -Level "WARNING"
     Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
+    Flush-Log
     exit 1
 }
 catch {
@@ -623,6 +626,7 @@ catch {
     Write-Host "ERROR: $($_.Exception.Message)"
     Write-Log -Message "Detection Result: ERROR (exit 1)" -Level "ERROR"
     Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"
+    Flush-Log
     exit 1
 }
 #endregion

--- a/Remediation/Secure Boot/Remediate-SecureBootCertificateUpdate.ps1
+++ b/Remediation/Secure Boot/Remediate-SecureBootCertificateUpdate.ps1
@@ -45,12 +45,15 @@
     Uses a 45-day fallback threshold and a custom registry path for the opt-in timestamp.
 
 .NOTES
-    Version:        3.0
+    Version:        3.1
     Author:         Mattias Melkersen
     Creation Date:  2026-01-15
     
     CHANGELOG
     ---------------
+    2026-04-05 - v3.1 - Buffered logging: accumulate entries in List[string], flush to disk once per run (MM)
+                        Added Flush-Log function; Write-Log no longer calls Add-Content on every line
+                        Replaced Start-Sleep -Seconds 10 with task-state polling loop after Step 1 task trigger
     2026-03-27 - v3.0 - Added configurable fallback timer with FallbackDays and TimestampRegPath parameters (MM)
                         When opt-in has been active for FallbackDays without compliance, triggers direct method
                         Writes ManagedOptInDate timestamp on first opt-in for fallback tracking
@@ -84,6 +87,7 @@ param(
 [string]$LogFile = "$env:ProgramData\Microsoft\IntuneManagementExtension\Logs\SecureBootCertificateUpdate.log"
 [string]$ScriptName = "REMEDIATE"
 [int]$MaxLogSizeMB = 4
+$script:LogBuffer = [System.Collections.Generic.List[string]]::new()
 
 function Write-Log {
     param(
@@ -93,40 +97,31 @@ function Write-Log {
         [ValidateSet("INFO", "WARNING", "ERROR", "SUCCESS")]
         [string]$Level = "INFO"
     )
-    
     $TimeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $LogEntry = "$TimeStamp [$ScriptName] [$Level] $Message"
-    
+    $script:LogBuffer.Add("$TimeStamp [$ScriptName] [$Level] $Message")
+}
+
+function Flush-Log {
+    if ($script:LogBuffer.Count -eq 0) { return }
     try {
-        # Ensure log directory exists
         $LogDir = Split-Path -Path $LogFile -Parent
         if (-not (Test-Path $LogDir)) {
             New-Item -Path $LogDir -ItemType Directory -Force | Out-Null
         }
-        
-        # Check log file size and rotate if necessary
         if (Test-Path $LogFile) {
             $LogFileSizeMB = (Get-Item $LogFile).Length / 1MB
             if ($LogFileSizeMB -ge $MaxLogSizeMB) {
-                # Rotate log: rename current to .old
                 $BackupLog = "$LogFile.old"
-                
-                # Delete old backup if it exists (keep only N-1)
                 if (Test-Path $BackupLog) {
                     Remove-Item -Path $BackupLog -Force -ErrorAction SilentlyContinue
                 }
-                
-                # Rename current log to backup
                 Rename-Item -Path $LogFile -NewName $BackupLog -Force -ErrorAction SilentlyContinue
-                
-                # Create new log file with rotation notice
-                $RotationMsg = "$TimeStamp [SYSTEM] [INFO] Log rotated - Previous log archived to: $BackupLog"
-                Add-Content -Path $LogFile -Value $RotationMsg -ErrorAction SilentlyContinue
+                $TimeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+                $script:LogBuffer.Insert(0, "$TimeStamp [SYSTEM] [INFO] Log rotated - Previous log archived to: $BackupLog")
             }
         }
-        
-        # Write to log file
-        Add-Content -Path $LogFile -Value $LogEntry -ErrorAction SilentlyContinue
+        Add-Content -Path $LogFile -Value $script:LogBuffer.ToArray() -ErrorAction SilentlyContinue
+        $script:LogBuffer.Clear()
     }
     catch {
         # Silently fail if logging doesn't work - don't break script execution
@@ -174,6 +169,7 @@ try {
         Write-Host "FAILED: Secure Boot DISABLED - Enable in BIOS/UEFI manually"
         Write-Log -Message "Remediation Result: FAILED (exit 1)" -Level "ERROR"
         Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+        Flush-Log
         exit 1
     }
     else {
@@ -227,6 +223,7 @@ try {
             Write-Host "ALREADY_CONFIGURED: OptIn 0x$($regValue.ToString('X')) already set. CA2023: $ca2023Text"
             Write-Log -Message "Remediation Result: ALREADY_CONFIGURED (exit 0)" -Level "SUCCESS"
             Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+            Flush-Log
             exit 0
         }
         
@@ -255,6 +252,7 @@ try {
             Write-Host "ALREADY_CONFIGURED: OptIn 0x$($regValue.ToString('X')) already set. CA2023: $ca2023Text. Fallback timer started."
             Write-Log -Message "Remediation Result: ALREADY_CONFIGURED (exit 0)" -Level "SUCCESS"
             Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+            Flush-Log
             exit 0
         }
         
@@ -272,6 +270,7 @@ try {
             Write-Host "ALREADY_CONFIGURED: OptIn 0x$($regValue.ToString('X')) already set. CA2023: $ca2023Text. Fallback in $($daysRemaining)d."
             Write-Log -Message "Remediation Result: ALREADY_CONFIGURED (exit 0)" -Level "SUCCESS"
             Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+            Flush-Log
             exit 0
         }
         
@@ -289,6 +288,7 @@ try {
             Write-Host "FALLBACK_BLOCKED: Scheduled task not found. CA2023: $ca2023Text"
             Write-Log -Message "Remediation Result: FALLBACK_BLOCKED (exit 1)" -Level "ERROR"
             Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+            Flush-Log
             exit 1
         }
         
@@ -312,7 +312,18 @@ try {
                 Start-ScheduledTask -TaskPath "\Microsoft\Windows\PI\" -TaskName "Secure-Boot-Update" -ErrorAction Stop
                 Write-Log -Message "  Step 1: Scheduled task triggered successfully" -Level "SUCCESS"
                 
-                Start-Sleep -Seconds 10
+                # Poll task completion rather than using a fixed sleep
+                $taskDeadline = (Get-Date).AddSeconds(60)
+                do {
+                    Start-Sleep -Seconds 2
+                    $taskState = (Get-ScheduledTask -TaskPath "\Microsoft\Windows\PI\" -TaskName "Secure-Boot-Update" -ErrorAction SilentlyContinue).State
+                } while ($taskState -eq 'Running' -and (Get-Date) -lt $taskDeadline)
+                if ($taskState -eq 'Running') {
+                    Write-Log -Message "  Step 1: Task still running after 60s timeout - proceeding to Step 2" -Level "WARNING"
+                }
+                else {
+                    Write-Log -Message "  Step 1: Task completed (State: $taskState)" -Level "INFO"
+                }
             }
             catch {
                 Write-Log -Message "  Step 1 FAILED: $($_.Exception.Message)" -Level "ERROR"
@@ -356,12 +367,14 @@ try {
             Write-Host "FALLBACK_APPLIED: Direct method triggered. CA2023 was: $ca2023Text. Reboot may be required."
             Write-Log -Message "Remediation Result: FALLBACK_APPLIED (exit 0)" -Level "SUCCESS"
             Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+            Flush-Log
             exit 0
         }
         else {
             Write-Host "FALLBACK_FAILED: Direct method encountered errors. CA2023: $ca2023Text"
             Write-Log -Message "Remediation Result: FALLBACK_FAILED (exit 1)" -Level "ERROR"
             Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+            Flush-Log
             exit 1
         }
     }
@@ -419,9 +432,11 @@ try {
         Write-Host "FAILED: Registry mismatch - Expected 0x$($regValue.ToString('X')), Got 0x$($currentValue.ToString('X'))"
         Write-Log -Message "Remediation Result: FAILED (exit 1)" -Level "ERROR"
         Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+        Flush-Log
         exit 1
     }
     
+    Flush-Log
     exit 0
 }
 catch {
@@ -430,6 +445,7 @@ catch {
     Write-Host "ERROR: $($_.Exception.Message)"
     Write-Log -Message "Remediation Result: ERROR (exit 1)" -Level "ERROR"
     Write-Log -Message "========== REMEDIATION COMPLETED ==========" -Level "INFO"
+    Flush-Log
     exit 1
 }
 #endregion


### PR DESCRIPTION
## Why

Three performance and reliability issues were identified in peer review of the Secure Boot certificate update scripts:

1. `Write-Log` called `Add-Content` on every single line, opening and closing the file handle for each log entry — wasteful across a fleet where these scripts run frequently.
2. The Detect script collected expensive diagnostic data (TPM, BitLocker, Windows Update COM object, pending reboot checks, registry dump) **before** checking whether the device was already fully compliant at Stage 5 — meaning compliant devices paid the full diagnostic cost on every run.
3. The Remediate script used `Start-Sleep -Seconds 10` after triggering the `Secure-Boot-Update` scheduled task for Step 1 — a fixed wait that either undershoots (if the task runs long) or wastes time on fast devices before proceeding to Step 2.

## What changed

**Both scripts — buffered logging**

`Write-Log` now appends entries to a `$script:LogBuffer` (`List[string]`) with zero file I/O. A new `Flush-Log` function performs directory creation, log rotation, and a single `Add-Content` call for the entire buffer. Every exit point in both scripts calls `Flush-Log` immediately before `exit`.

**Detect script — Stage 5 early exit**

The Stage 5 compliance check (`WindowsUEFICA2023Capable -eq 2`) is now evaluated immediately after reading the registry values, before the diagnostic data block. Fully compliant devices exit without ever instantiating `Win32_Tpm`, `Win32_EncryptableVolume`, the Windows Update COM object, or querying pending-reboot registry keys.

**Remediate script — polling the scheduled task**

The `Start-Sleep -Seconds 10` after Step 1's `Start-ScheduledTask` call is replaced with a `do/while` polling loop that checks task `State` every 2 seconds up to a 60-second timeout. This ensures Step 2 doesn't start before the task has actually finished, and doesn't wait longer than necessary on fast devices.

## Files changed

- `Remediation/Secure Boot/Detect-SecureBootCertificateUpdate.ps1` — v3.0 → v3.1
- `Remediation/Secure Boot/Remediate-SecureBootCertificateUpdate.ps1` — v3.0 → v3.1