### PR TITLE
Cleanup tracking registry key when device reaches Stage 5 compliance

### DIFF
--- a/Remediation/Secure Boot/Detect-SecureBootCertificateUpdate.ps1
+++ b/Remediation/Secure Boot/Detect-SecureBootCertificateUpdate.ps1
@@ -432,6 +432,18 @@ try {
         Write-Log -Message "--- Stage 5: COMPLIANT ---" -Level "SUCCESS"
         Write-Log -Message "  Device is booting from the 2023-signed boot manager" -Level "SUCCESS"
         Write-Log -Message "  The Secure Boot certificate transition is complete for this device" -Level "SUCCESS"
+
+        # Cleanup: remove tracking registry key now that transition is complete
+        if (Test-Path $TimestampRegPath) {
+            try {
+                Remove-Item -Path $TimestampRegPath -Recurse -Force -ErrorAction Stop
+                Write-Log -Message "  Cleanup: Removed $TimestampRegPath (no longer needed)" -Level "SUCCESS"
+            }
+            catch {
+                Write-Log -Message "  Cleanup: Could not remove $TimestampRegPath - $($_.Exception.Message)" -Level "WARNING"
+            }
+        }
+
         Write-Host "COMPLIANT | $details"
         Write-Log -Message "Detection Result: COMPLIANT - Stage 5 (exit 0)" -Level "SUCCESS"
         Write-Log -Message "========== DETECTION COMPLETED ==========" -Level "INFO"


### PR DESCRIPTION
Devices that complete the Secure Boot certificate transition leave behind the fallback timer tracking registry key (ManagedOptInDate). This key is only used during the transition and serves no purpose after compliance is reached. The detection script now removes it automatically at Stage 5 to keep the registry clean across the fleet.